### PR TITLE
Upgrade pip and setuptools in workflow

### DIFF
--- a/.github/workflows/caseologue_python.yml
+++ b/.github/workflows/caseologue_python.yml
@@ -35,6 +35,7 @@ jobs:
   
     - name: Install requirements
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r caseologue_python/requirements.txt
 
     - name: run 

--- a/.github/workflows/caseologue_python.yml
+++ b/.github/workflows/caseologue_python.yml
@@ -35,7 +35,8 @@ jobs:
   
     - name: Install requirements
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        pip install --force-reinstall --no-cache-dir setuptools wheel pip
+        pip install --force-reinstall importlib-metadata
         pip install -r caseologue_python/requirements.txt
 
     - name: run 

--- a/.github/workflows/test_caseologue.yml
+++ b/.github/workflows/test_caseologue.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install requirements
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r caseologue_python/requirements.txt
     - name: run test_caseologue
       if: always()

--- a/caseologue_python/requirements.txt
+++ b/caseologue_python/requirements.txt
@@ -1,7 +1,7 @@
-rdflib==7.0.0
-pandas==2.0.3
-numpy==1.26.4
-argparse==1.4.0
-tabulate==0.9.0
-lxml==4.9.3
-codespell==2.2.5
+rdflib>=7.0.0
+pandas>=2.0.3
+numpy>=1.26.4
+argparse>=1.4.0
+tabulate>=0.9.0
+lxml>=4.9.3
+codespell>=2.2.5


### PR DESCRIPTION
fix failing workflows due to:
```
× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> [20 lines of output]
Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
main()
File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
json_out['return_val'] = hook(**hook_input['kwargs'])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
return hook(config_settings)
^^^^^^^^^^^^^^^^^^^^^
File "/tmp/pip-build-env-2uuifzml/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
return self._get_build_requires(config_settings, requirements=[])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/tmp/pip-build-env-2uuifzml/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 301, in _get_build_requires
self.run_setup()
File "/tmp/pip-build-env-2uuifzml/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 520, in run_setup
super().run_setup(setup_script=setup_script)
File "/tmp/pip-build-env-2uuifzml/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 317, in run_setup
exec(code, locals())
File "<string>", line 19, in <module>
ModuleNotFoundError: No module named 'pkg_resources'
```